### PR TITLE
Fix Date Bug

### DIFF
--- a/client/src/views/NewEvent.vue
+++ b/client/src/views/NewEvent.vue
@@ -68,11 +68,11 @@ export default {
       }
       return num;
     };
-    this.sdate = `${a.getFullYear()}-${appendZero(a.getMonth())}-${appendZero(
+    this.sdate = `${a.getFullYear()}-${appendZero(a.getMonth() + 1)}-${appendZero(
       a.getDate()
     )}`;
     a.setDate(a.getDate() + 5);
-    this.edate = `${a.getFullYear()}-${appendZero(a.getMonth())}-${appendZero(
+    this.edate = `${a.getFullYear()}-${appendZero(a.getMonth() + 1)}-${appendZero(
       a.getDate()
     )}`;
   },


### PR DESCRIPTION
getMonth() returns January as 0, February as 1, and so on. Therefore it requires +1 to display the current month